### PR TITLE
Fix GetTag to return the NotFound error when the tag does not exist

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -212,17 +212,16 @@ func (g *GitlabClient) ListTagsUntil(tag_name string) ([]*gitlab.Tag, error) {
 	return allTags, nil
 }
 
-
 func (g *GitlabClient) GetTag(tag_name string) (*gitlab.Tag, error) {
-	tag, res, err := g.client.Tags.GetTag(g.repository, tag_name)
+	tag, resp, err := g.client.Tags.GetTag(g.repository, tag_name)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, NotFound
+		}
 		return nil, err
 	}
 
-	defer res.Body.Close()
-	if res.StatusCode == http.StatusNotFound {
-		return nil, NotFound
-	}
+	defer resp.Body.Close()
 	return tag, nil
 }
 

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -118,6 +118,21 @@ var _ = Describe("GitLab Client", func() {
 				Expect(tag).To(Equal(expectedTag))
 			})
 		})
+
+		Context("The tag does not exist", func() {
+			BeforeEach(func () {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v4/projects/concourse/repository/tags/some-tag"),
+						ghttp.RespondWith(404, `{ "message": "404 Tag Not Found" }`),
+					),
+				)
+			})
+			It("Returns the NotFound error", func() {
+				_, err := client.GetTag("some-tag")
+				Expect(err).To(Equal(NotFound))
+			})
+		})
 	})
 
 	Describe("GetRelease", func() {


### PR DESCRIPTION
The test code matched what GitLab returns when no tag is found. GetTag properly handles this error response and will return the NotFound error type.

This allows `ensureTag()` to behave correctly when `commitish` is used.