### PR TITLE
Args in CreateTag declaration do not match those in the definition.

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -244,7 +244,7 @@ func (g *GitlabClient) GetRelease(tag_name string) (*gitlab.Release, error) {
 	return release, nil
 }
 
-func (g *GitlabClient) CreateTag(ref string, tag_name string) (*gitlab.Tag, error) {
+func (g *GitlabClient) CreateTag(tag_name string, ref string) (*gitlab.Tag, error) {
 	opt := &gitlab.CreateTagOptions{
 		TagName: gitlab.String(tag_name),
 		Ref:     gitlab.String(ref),


### PR DESCRIPTION
The function declaration for `CreateTag` is this:

```golang
type GitLab interface {
...
	CreateTag(tag_name string, ref string) (*gitlab.Tag, error)
...
}
```

With the tag name first, then the commit sha reference. However in the function definition:

```golang
func (g *GitlabClient) CreateTag(ref string, tag_name string) (*gitlab.Tag, error) {
...
}
```

the args are ref first, followed by tag name.